### PR TITLE
Add : 월드컵 페이지에서 처음에 리스트 배열 섞어주는 로직 추가

### DIFF
--- a/db.json
+++ b/db.json
@@ -4,88 +4,88 @@
       "title": "음식월드컵",
       "list": [
         {
-          "id": "d1b3a754-4db4-4fdc-9d6d-d70e155fa57e",
-          "candidate": "양곱창",
-          "score": 5
-        },
-        {
-          "id": "8fc8f825-8b0a-45d4-b498-012fdb633e10",
-          "candidate": "소곱창",
-          "score": 8
-        },
-        {
-          "id": "269a85ff-e0d9-4438-a5d7-b91fb138eaba",
-          "candidate": "순댓국",
-          "score": 5
-        },
-        {
-          "id": "86aec635-bbac-4d0e-a21f-0fa6ce7a4156",
-          "candidate": "칼국수",
-          "score": 12
+          "id": "ced30966-1056-4e6f-8136-774973be232d",
+          "candidate": "콩나물국",
+          "score": 28
         },
         {
           "id": "af49b2e5-08cc-4b25-9a9b-93cec88033a5",
           "candidate": "김치국",
-          "score": 5
-        },
-        {
-          "id": "1f138893-15d2-40ef-bf87-4310f45d6a66",
-          "candidate": "호박찜",
-          "score": 5
-        },
-        {
-          "id": "d4cb8a8f-ffcf-4b7f-8acd-4505d969a4e2",
-          "candidate": "김치돼지갈비찜",
-          "score": 4
-        },
-        {
-          "id": "7468db7b-2dfb-4a93-98aa-3927faab175e",
-          "candidate": "비빔밥",
-          "score": 14
-        },
-        {
-          "id": "bceadd0e-1ea4-4fe6-a559-b50f9f8797d2",
-          "candidate": "돼지갈비",
-          "score": 7
-        },
-        {
-          "id": "a04f735c-f78f-44e8-89e3-9762be3f209d",
-          "candidate": "삼겹살",
-          "score": 5
-        },
-        {
-          "id": "7c7156bd-a75e-4a89-a0a9-8da79c4684b0",
-          "candidate": "된장찌개",
-          "score": 2
-        },
-        {
-          "id": "ced30966-1056-4e6f-8136-774973be232d",
-          "candidate": "콩나물국",
-          "score": 12
-        },
-        {
-          "id": "19a54ba5-794a-4359-8477-51392e78af7f",
-          "candidate": "콩자반",
-          "score": 2
-        },
-        {
-          "id": "0e7348b8-6c50-42f6-a68b-1b844eddf9ba",
-          "candidate": "두부부침",
-          "score": 8
+          "score": 17
         },
         {
           "id": "db300846-4a04-4a0c-8be0-73cc5a778349",
           "candidate": "코다리찜",
-          "score": 5
+          "score": 18
+        },
+        {
+          "id": "d1b3a754-4db4-4fdc-9d6d-d70e155fa57e",
+          "candidate": "양곱창",
+          "score": 26
+        },
+        {
+          "id": "7c7156bd-a75e-4a89-a0a9-8da79c4684b0",
+          "candidate": "된장찌개",
+          "score": 11
+        },
+        {
+          "id": "d4cb8a8f-ffcf-4b7f-8acd-4505d969a4e2",
+          "candidate": "김치돼지갈비찜",
+          "score": 19
+        },
+        {
+          "id": "a04f735c-f78f-44e8-89e3-9762be3f209d",
+          "candidate": "삼겹살",
+          "score": 15
+        },
+        {
+          "id": "8fc8f825-8b0a-45d4-b498-012fdb633e10",
+          "candidate": "소곱창",
+          "score": 21
+        },
+        {
+          "id": "86aec635-bbac-4d0e-a21f-0fa6ce7a4156",
+          "candidate": "칼국수",
+          "score": 30
+        },
+        {
+          "id": "19a54ba5-794a-4359-8477-51392e78af7f",
+          "candidate": "콩자반",
+          "score": 17
+        },
+        {
+          "id": "0e7348b8-6c50-42f6-a68b-1b844eddf9ba",
+          "candidate": "두부부침",
+          "score": 15
         },
         {
           "id": "6b8caa81-5fe8-4acd-9536-05cd81afcc77",
           "candidate": "불고기",
-          "score": 21
+          "score": 52
+        },
+        {
+          "id": "1f138893-15d2-40ef-bf87-4310f45d6a66",
+          "candidate": "호박찜",
+          "score": 14
+        },
+        {
+          "id": "7468db7b-2dfb-4a93-98aa-3927faab175e",
+          "candidate": "비빔밥",
+          "score": 36
+        },
+        {
+          "id": "269a85ff-e0d9-4438-a5d7-b91fb138eaba",
+          "candidate": "순댓국",
+          "score": 12
+        },
+        {
+          "id": "bceadd0e-1ea4-4fe6-a559-b50f9f8797d2",
+          "candidate": "돼지갈비",
+          "score": 29
         }
       ],
       "id": "329fbe57-a354-4d22-8614-1f205b5fb1ac",
-      "count": 0,
+      "count": 10,
       "createdAt": 1646472577229,
       "comments": []
     },
@@ -265,6 +265,362 @@
       "id": "78d36270-a029-457a-9a39-f6c547c80ae2",
       "count": 0,
       "createdAt": 1646473055851,
+      "comments": []
+    },
+    {
+      "title": "로아 개사기 직업 월드컵",
+      "list": [
+        {
+          "id": "dec0e00c-d337-46a1-ac5d-e6f50fd09e9d",
+          "candidate": "창술사",
+          "score": 5
+        },
+        {
+          "id": "079d8c7e-250b-41f8-b374-a83cfb820abe",
+          "candidate": "바드 . ",
+          "score": 0
+        },
+        {
+          "id": "c7060375-16c9-49b2-a519-c34eb1780482",
+          "candidate": "인파이터 ",
+          "score": 2
+        },
+        {
+          "id": "8c80ebe4-90c4-487e-b0b9-5f2449c6dc2f",
+          "candidate": "기공사",
+          "score": 1
+        },
+        {
+          "id": "9f6a9666-afc5-4fab-85d7-26a3517a0404",
+          "candidate": "배틀마스터",
+          "score": 1
+        },
+        {
+          "id": "f34b45ad-eac7-474e-80cf-e195f8e2bd0b",
+          "candidate": "워로드",
+          "score": 1
+        },
+        {
+          "id": "ca3c31e3-b666-40f9-bcfe-7e45aa25d232",
+          "candidate": "버서커",
+          "score": 5
+        },
+        {
+          "id": "88754f6b-d8f9-4263-8ab1-482228ee35a7",
+          "candidate": "디스트로이어",
+          "score": 0
+        },
+        {
+          "id": "e8fde393-1cd7-4295-9fb4-3e9ed2a559b7",
+          "candidate": "호크아이",
+          "score": 1
+        },
+        {
+          "id": "47af7607-bcea-47a4-8415-a86b12bbe0e4",
+          "candidate": "스카우터",
+          "score": 2
+        },
+        {
+          "id": "66512ed3-cf7e-4ea9-aef8-381c40b62d9c",
+          "candidate": "데빌헌터",
+          "score": 1
+        },
+        {
+          "id": "02db8d24-7aff-4cce-86f6-67218ca878a1",
+          "candidate": "블래스터",
+          "score": 3
+        },
+        {
+          "id": "c12bbc8d-4ea3-48bd-a7cc-ffa2a1185c5b",
+          "candidate": "블레이드",
+          "score": 4
+        },
+        {
+          "id": "700f4c2e-5c63-4fe8-bc26-a38f61135531",
+          "candidate": "리퍼.",
+          "score": 2
+        },
+        {
+          "id": "bd4fa81c-a866-436a-a8ee-d5d932b08286",
+          "candidate": "데모닉",
+          "score": 1
+        },
+        {
+          "id": "39277194-027f-4131-830d-52e79f377595",
+          "candidate": "건슬링어",
+          "score": 1
+        }
+      ],
+      "id": "31c0e56f-c18c-49e8-b326-542b97eb2901",
+      "count": 1,
+      "createdAt": 1646501869114,
+      "comments": []
+    },
+    {
+      "title": "테스트 월드컵",
+      "list": [
+        {
+          "id": "dad277f4-0ed4-4f51-965f-86ee2efcc618",
+          "candidate": "ㄲㄲㄱ",
+          "score": 1
+        },
+        {
+          "id": "193c6e6f-4269-4bb1-ae45-79263e882214",
+          "candidate": "ㅎㅎㅎㅎㅎㅎ",
+          "score": 2
+        },
+        {
+          "id": "3bc490df-2a42-4f69-94d5-a77a8a19b06b",
+          "candidate": "ㅌㅌㅌㅌㅌㅌ",
+          "score": 1
+        },
+        {
+          "id": "379e55be-e3e2-41c2-8ade-7d210edf7e8c",
+          "candidate": "ㄸㄸㄸ",
+          "score": 0
+        },
+        {
+          "id": "692134b1-b565-4ba0-9ef3-e0bd079329d9",
+          "candidate": "ㅊㅊㅊㅊㅊㅊ",
+          "score": 2
+        },
+        {
+          "id": "ff80ebf1-06e5-49e6-a204-749605937fb0",
+          "candidate": "ㅁㅁㅁㅁㅁㅁ",
+          "score": 5
+        },
+        {
+          "id": "240f8226-edd4-49d0-a119-4394bdf3eed2",
+          "candidate": "ㅆㅆㅆ",
+          "score": 6
+        },
+        {
+          "id": "1f8506b3-bd52-468e-91e2-5958b81bdf55",
+          "candidate": "ㅋㅋㅋㅋㅋㅋ",
+          "score": 9
+        },
+        {
+          "id": "d6d87172-f1f9-418b-87f8-05ed20f54fb1",
+          "candidate": "ㄹㄹㄹㄹㄹ",
+          "score": 3
+        },
+        {
+          "id": "eb73f87c-8d26-4e05-8f15-d5e4de0a8880",
+          "candidate": "ㅉㅉㅉ",
+          "score": 3
+        },
+        {
+          "id": "0832afd0-8945-45cd-a1df-160f8017226e",
+          "candidate": "ㅃㅃㅃㅂ",
+          "score": 1
+        },
+        {
+          "id": "4baed498-a3b6-43ca-a4db-6b339520b843",
+          "candidate": "ㅇㅇㅇㅇㅇ",
+          "score": 0
+        },
+        {
+          "id": "b21b88df-e14a-4812-b05c-cb89288a6bc6",
+          "candidate": "ㅍㅍㅍㅍㅍㅎㅎ",
+          "score": 2
+        },
+        {
+          "id": "e91133b6-dea4-481e-a20c-049deb5e06e2",
+          "candidate": "ㅏㅏㅏㅏ",
+          "score": 6
+        },
+        {
+          "id": "6eca391a-7d98-4e4d-934a-778291236616",
+          "candidate": "ㄴㄴㄴㄴ",
+          "score": 2
+        },
+        {
+          "id": "4b79909e-b409-4c2b-ab3d-7d8de2ed79df",
+          "candidate": "ㅔㅔㅔㅔㅔㅔㅔ",
+          "score": 2
+        }
+      ],
+      "id": "945fed7a-f815-4f8f-b15b-c7a7b3972bdd",
+      "count": 5,
+      "createdAt": 1646511015415,
+      "comments": []
+    },
+    {
+      "title": "테스트 월드컵",
+      "list": [
+        {
+          "id": "069c4381-6f8e-41ce-9737-3cdd6c51ef72",
+          "candidate": "eee",
+          "score": 7
+        },
+        {
+          "id": "1cc8ac44-b09e-48b0-80f3-2b423c9a8725",
+          "candidate": "4444",
+          "score": 1
+        },
+        {
+          "id": "608d57d8-e053-4eba-8ff9-efa4d6e3c9b4",
+          "candidate": "ddd",
+          "score": 5
+        },
+        {
+          "id": "8750b285-54d9-41a7-b10b-c226b4bcf81b",
+          "candidate": "888",
+          "score": 4
+        },
+        {
+          "id": "add40c91-4e78-4ab8-b505-657acfa76cd3",
+          "candidate": "777",
+          "score": 4
+        },
+        {
+          "id": "3f8f56e5-6139-45a4-8e85-fb1b36d6acce",
+          "candidate": "333",
+          "score": 1
+        },
+        {
+          "id": "714bb5dd-936c-416c-80f5-c94f68e530db",
+          "candidate": "222",
+          "score": 5
+        },
+        {
+          "id": "aacd1cd1-32ed-4d94-b855-a36dcec9b60f",
+          "candidate": "555",
+          "score": 0
+        },
+        {
+          "id": "5d1cf07a-d409-4ee9-b5b9-330b9ef8b613",
+          "candidate": "ggg",
+          "score": 4
+        },
+        {
+          "id": "ebaab1f0-a7c0-48b1-9146-d4ddf06e783e",
+          "candidate": "fff",
+          "score": 1
+        },
+        {
+          "id": "aaa8f522-b512-43e4-8675-a11a83288774",
+          "candidate": "aaaa",
+          "score": 5
+        },
+        {
+          "id": "8e9c4882-1188-4fc6-8944-9d01242c2c04",
+          "candidate": "ccc",
+          "score": 2
+        },
+        {
+          "id": "86911f9f-73f1-4482-bbbf-456d15148400",
+          "candidate": "999",
+          "score": 3
+        },
+        {
+          "id": "d67631fe-1a7f-48b0-9e22-d9f605984a72",
+          "candidate": "111",
+          "score": 5
+        },
+        {
+          "id": "d973c38f-0ddf-4122-bcf1-f6d0424873d0",
+          "candidate": "666",
+          "score": 3
+        },
+        {
+          "id": "0c302c98-50c7-4dd3-973e-e76e302f6449",
+          "candidate": "bbb",
+          "score": 5
+        }
+      ],
+      "id": "5e4ddb2d-a626-4cac-8c0f-dc08ff72a085",
+      "count": 4,
+      "createdAt": 1646556028726,
+      "comments": []
+    },
+    {
+      "title": "테스트월드컵33",
+      "list": [
+        {
+          "id": "33ed7396-fcff-4fbb-a9c4-ba33ad30f48c",
+          "candidate": "카카카",
+          "score": 4
+        },
+        {
+          "id": "31a547c9-5319-4aa9-9d3f-d9c05128c6da",
+          "candidate": "222",
+          "score": 0
+        },
+        {
+          "id": "ed90df7b-4984-4f6d-8e9c-e46ac232614a",
+          "candidate": "아아아",
+          "score": 1
+        },
+        {
+          "id": "4e66217a-e823-4094-b8ef-603f1517dc40",
+          "candidate": "다다다",
+          "score": 0
+        },
+        {
+          "id": "3f927d5f-2b01-468f-99c0-21d06422f9ce",
+          "candidate": "111",
+          "score": 2
+        },
+        {
+          "id": "293db475-b7cf-493b-8158-5277d6b46d82",
+          "candidate": "바바바",
+          "score": 0
+        },
+        {
+          "id": "e95a0bd3-4ee2-4232-b59c-c7643a59548a",
+          "candidate": "라라라",
+          "score": 1
+        },
+        {
+          "id": "2db8017d-a0e9-4ccf-a207-5121e82b3846",
+          "candidate": "가가가",
+          "score": 0
+        },
+        {
+          "id": "92b057f6-09e0-452f-b0df-7a02794ed652",
+          "candidate": "자자자",
+          "score": 3
+        },
+        {
+          "id": "c47a0518-2667-49b3-b448-fcf619882b41",
+          "candidate": "나나나",
+          "score": 0
+        },
+        {
+          "id": "cbf1a1dc-471b-4362-9876-b20caa7f94af",
+          "candidate": "마마마",
+          "score": 1
+        },
+        {
+          "id": "f4f27b55-3879-44f6-ab80-310ddb16c103",
+          "candidate": "파파파",
+          "score": 0
+        },
+        {
+          "id": "bd6b1391-3bb1-4f43-a635-aafc370cd5c2",
+          "candidate": "타타타",
+          "score": 2
+        },
+        {
+          "id": "db3c114c-d9bb-45ea-97ae-095d5a61eaf4",
+          "candidate": "차차차",
+          "score": 0
+        },
+        {
+          "id": "e45dcb46-74a6-41fc-82fc-f8ff6864c8b1",
+          "candidate": "하하하",
+          "score": 1
+        },
+        {
+          "id": "8c968a26-1b83-4689-aed0-1a1c5b9aacd3",
+          "candidate": "사사사",
+          "score": 0
+        }
+      ],
+      "id": "365ee042-60ae-4f9e-b3be-de9267bcbe3e",
+      "count": 1,
+      "createdAt": 1646556453356,
       "comments": []
     }
   ]

--- a/db.json
+++ b/db.json
@@ -1,140 +1,729 @@
 {
   "world": [
     {
-      "title": "월",
+      "title": "음식 월드컵 ",
       "list": [
         {
-          "id": "d0831be3-747d-4d03-a699-64dd0b26df7d",
-          "candidate": "1",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "4a0ab2d2-fb47-4270-a488-bbca89582aea",
+          "candidate": "피자",
+          "roundWin": 27,
+          "roundLose": 24,
+          "champion": 3
+        },
+        {
+          "id": "1a43bc2a-f7a7-46e1-af78-5a52848ff603",
+          "candidate": "김치",
+          "roundWin": 25,
+          "roundLose": 24,
+          "champion": 3
+        },
+        {
+          "id": "57db1541-f51f-4502-87c7-c82b4a30e522",
+          "candidate": "짬뽕",
+          "roundWin": 20,
+          "roundLose": 27,
           "champion": 0
         },
         {
-          "id": "70223f72-076b-49ec-a45a-59dbd815682c",
-          "candidate": "2",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "82522aae-c8fc-4e4d-9c86-52b8cc595d94",
+          "candidate": "라면",
+          "roundWin": 15,
+          "roundLose": 27,
           "champion": 0
         },
         {
-          "id": "37f49423-aea8-4ebe-864c-3c398491f408",
-          "candidate": "3",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "4c0ebba0-2ef9-440d-9714-12f833b7a6e3",
+          "candidate": "샐러드",
+          "roundWin": 22,
+          "roundLose": 27,
           "champion": 0
         },
         {
-          "id": "454d0e91-4e59-4ca1-b7cf-feff7261a643",
-          "candidate": "4",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "6f550cc1-dff4-4032-9087-5dc9d262dc74",
+          "candidate": "김치볶음밥",
+          "roundWin": 27,
+          "roundLose": 25,
+          "champion": 2
+        },
+        {
+          "id": "a491d780-ff7b-411b-83ef-537356fa8784",
+          "candidate": "떡볶이",
+          "roundWin": 20,
+          "roundLose": 26,
+          "champion": 1
+        },
+        {
+          "id": "c17f5bcb-46a1-45f8-bc41-f703ddba39f3",
+          "candidate": "삼겹살",
+          "roundWin": 21,
+          "roundLose": 27,
           "champion": 0
         },
         {
-          "id": "84e1f877-4042-446f-b55b-09532e5e852f",
-          "candidate": "5",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "7fa11373-aa8d-4d99-873d-9fe96f3bde2b",
+          "candidate": "돼지갈비",
+          "roundWin": 36,
+          "roundLose": 24,
+          "champion": 3
+        },
+        {
+          "id": "1896b7b1-1177-4730-a783-408595a778cf",
+          "candidate": "보쌈",
+          "roundWin": 38,
+          "roundLose": 22,
+          "champion": 5
+        },
+        {
+          "id": "14075f40-ca09-4c8c-9d59-c02041426e30",
+          "candidate": "새우튀김",
+          "roundWin": 26,
+          "roundLose": 25,
+          "champion": 2
+        },
+        {
+          "id": "3bde6cdf-a854-4d0f-b367-198377c68516",
+          "candidate": "국밥",
+          "roundWin": 28,
+          "roundLose": 24,
+          "champion": 3
+        },
+        {
+          "id": "d6d49789-806f-4eaa-a3a9-2b0687039fb4",
+          "candidate": "치킨 ",
+          "roundWin": 29,
+          "roundLose": 26,
+          "champion": 1
+        },
+        {
+          "id": "dff2835d-342e-4d84-95ab-4046348b5c49",
+          "candidate": "닭볶음탕",
+          "roundWin": 30,
+          "roundLose": 25,
+          "champion": 2
+        },
+        {
+          "id": "913742ee-c61d-4bb0-8427-141daacfa57f",
+          "candidate": "찜닭",
+          "roundWin": 11,
+          "roundLose": 27,
           "champion": 0
         },
         {
-          "id": "33a815f7-2e55-4103-97ba-3386263d1bf1",
-          "candidate": "6",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
-          "champion": 0
-        },
+          "id": "df18fa49-9289-4dfe-a606-8f49446cdb2e",
+          "candidate": "족발",
+          "roundWin": 30,
+          "roundLose": 25,
+          "champion": 2
+        }
+      ],
+      "id": "62aa538c-aefb-4a0b-b99d-e6ef4bda1df8",
+      "count": 27,
+      "createdAt": 1646562077549,
+      "comments": []
+    },
+    {
+      "title": "das",
+      "list": [
         {
-          "id": "771e2113-bd71-4cce-8d17-262a6dccf304",
-          "candidate": "7",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
-          "champion": 0
-        },
-        {
-          "id": "4b360218-d12c-4d84-b316-119f1fa21717",
-          "candidate": "8",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
-          "champion": 0
-        },
-        {
-          "id": "8de17c88-8a1b-4c50-b54d-b174ce6537ea",
+          "id": "915ebf38-2070-4db5-a831-34083fe276b5",
           "candidate": "9",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "roundWin": 5,
+          "roundLose": 2,
+          "champion": 1
+        },
+        {
+          "id": "70059722-edd6-486b-980d-455fab7aa441",
+          "candidate": "gj",
+          "roundWin": 4,
+          "roundLose": 2,
+          "champion": 1
+        },
+        {
+          "id": "e6604e58-fc15-4135-a33e-f7dc90b8d986",
+          "candidate": "asd",
+          "roundWin": 6,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "5257398b-3d0a-4402-8cda-b5e19f8e40c6",
-          "candidate": "10",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "11e06c5e-852c-45d3-9141-64a7646e990d",
+          "candidate": "b",
+          "roundWin": 2,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "c74d7d89-cc2b-4605-b790-fef0cd22929e",
-          "candidate": "11",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "819cb30f-17a1-46ba-b550-073499286797",
+          "candidate": "6",
+          "roundWin": 6,
+          "roundLose": 2,
+          "champion": 1
+        },
+        {
+          "id": "b8d511b1-f72a-425c-a274-3f8f0c037a79",
+          "candidate": "k",
+          "roundWin": 1,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "1752a3ee-07b3-43e5-8c97-a0d92a6dd39b",
-          "candidate": "12",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "8c527469-b865-4ddc-ae5e-b82896b2c8ff",
+          "candidate": "j21213",
+          "roundWin": 1,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "c050fc31-fb31-475c-b2c5-48c698094b0e",
-          "candidate": "13",
-          "score": 0,
+          "id": "1f81f082-570b-41c7-9750-ca6f32171c26",
+          "candidate": "ufth",
           "roundWin": 0,
-          "roundLose": 0,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "471e8f84-e258-4094-8101-10d87d5466f4",
-          "candidate": "14",
-          "score": 0,
-          "roundWin": 0,
-          "roundLose": 0,
+          "id": "9fc0b68d-cd9a-4668-b6bd-3a55da7de25f",
+          "candidate": "hu",
+          "roundWin": 5,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "7e565790-2473-46ff-bc05-c5e6658bbc81",
-          "candidate": "15",
-          "score": 0,
+          "id": "420eea4b-6efe-4484-9a39-66daa32282db",
+          "candidate": "h",
           "roundWin": 0,
-          "roundLose": 0,
+          "roundLose": 3,
           "champion": 0
         },
         {
-          "id": "279cdbcc-eb7b-4448-bb08-ed3c663b34ba",
-          "candidate": "16",
-          "score": 0,
+          "id": "fced0deb-b6e2-4633-b892-ec7daa5e0c05",
+          "candidate": "t",
+          "roundWin": 3,
+          "roundLose": 3,
+          "champion": 0
+        },
+        {
+          "id": "27b232d7-e882-4318-9e5b-17e8f37a2801",
+          "candidate": "kn",
+          "roundWin": 2,
+          "roundLose": 3,
+          "champion": 0
+        },
+        {
+          "id": "476b2c02-aa40-4c82-b17b-7db0cfadc9c1",
+          "candidate": "i0",
+          "roundWin": 3,
+          "roundLose": 3,
+          "champion": 0
+        },
+        {
+          "id": "9237f224-3ef2-4efc-b08e-a013dc8a4328",
+          "candidate": "7",
+          "roundWin": 3,
+          "roundLose": 3,
+          "champion": 0
+        },
+        {
+          "id": "eeda1e5d-d815-4092-8382-84a79b92c976",
+          "candidate": "jk",
+          "roundWin": 4,
+          "roundLose": 3,
+          "champion": 0
+        },
+        {
+          "id": "3ee917e7-017a-4333-b909-52219d7af857",
+          "candidate": "j",
           "roundWin": 0,
-          "roundLose": 0,
+          "roundLose": 3,
           "champion": 0
         }
       ],
-      "id": "6cdd7a33-9395-4d44-aa48-b7d082af537a",
-      "count": 0,
-      "createdAt": 1646559455739,
+      "id": "495d5486-0389-441f-9918-2b26893be6e8",
+      "count": 3,
+      "createdAt": 1646563541988,
+      "comments": []
+    },
+    {
+      "title": "7",
+      "list": [
+        {
+          "id": "d4fc5e62-931b-4864-b2c7-efda196c2fa9",
+          "candidate": "y",
+          "roundWin": 7,
+          "roundLose": 3,
+          "champion": 1
+        },
+        {
+          "id": "1752b33e-6945-4469-964b-51ca29da23bc",
+          "candidate": "u",
+          "roundWin": 1,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "9fb04cc6-c9b1-43e8-a0c1-e1eabb674f26",
+          "candidate": "jn",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "66351db0-d8fe-4437-a0ad-8c45efce5b7b",
+          "candidate": "v",
+          "roundWin": 0,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "c2a575b0-ccd1-4aca-b4aa-c9405a9763cb",
+          "candidate": "g",
+          "roundWin": 2,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "7b082b03-34fb-49f6-93f3-0f72055825f9",
+          "candidate": "b",
+          "roundWin": 1,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "afb19b03-d6bb-47d7-9afc-75990d325698",
+          "candidate": "h",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "38b7155d-9fe2-4764-a80f-d1f4db69f6f5",
+          "candidate": "m",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "25ae20f1-4e7e-4e6c-b92e-b42695b27fba",
+          "candidate": "k",
+          "roundWin": 12,
+          "roundLose": 2,
+          "champion": 2
+        },
+        {
+          "id": "8a4e0f32-8001-4f17-924b-08c6a5a649cb",
+          "candidate": "p",
+          "roundWin": 1,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "b3e27d8a-f250-483c-947e-964d1c4eaefe",
+          "candidate": "h",
+          "roundWin": 1,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "68b2f628-c3f3-468b-9678-c6684220ee60",
+          "candidate": "i",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "7a31cc69-4050-4ea3-9c73-b27d2888e809",
+          "candidate": "b",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "9cac6172-06c1-4684-88ce-9f35e168d42b",
+          "candidate": "o",
+          "roundWin": 5,
+          "roundLose": 4,
+          "champion": 0
+        },
+        {
+          "id": "c2ff48fa-523b-4a5f-82cd-1e8ffbd456c5",
+          "candidate": "l",
+          "roundWin": 6,
+          "roundLose": 3,
+          "champion": 1
+        },
+        {
+          "id": "985dece5-9e87-41ed-94f2-c4dc665294fd",
+          "candidate": "c",
+          "roundWin": 4,
+          "roundLose": 4,
+          "champion": 0
+        }
+      ],
+      "id": "883a191f-a456-44eb-84e2-4e41c1f76406",
+      "count": 4,
+      "createdAt": 1646563671358,
+      "comments": []
+    },
+    {
+      "title": "213",
+      "list": [
+        {
+          "id": "4807ac06-a4f9-4d7e-97c6-416e86a2726c",
+          "candidate": "c",
+          "roundWin": 10,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "e011f3fd-4917-4767-87a8-255258607c0a",
+          "candidate": "h",
+          "roundWin": 3,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "f5771be3-883a-4770-a71f-ba8c1db977df",
+          "candidate": "x",
+          "roundWin": 7,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "e78aa7b3-0dc0-48cb-8096-37a4a12543e1",
+          "candidate": "d",
+          "roundWin": 5,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "6fb52b78-051b-47d4-9259-45ec40dd2196",
+          "candidate": "g",
+          "roundWin": 6,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "78323a6c-c6a5-494c-813d-02cad03407fc",
+          "candidate": "u",
+          "roundWin": 2,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "50d781f9-2342-44d7-b5f7-9e379e514eda",
+          "candidate": "b",
+          "roundWin": 5,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "0b43ca00-9801-4a26-81ff-0b59e370b534",
+          "candidate": "r",
+          "roundWin": 5,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "26e30274-b562-48ec-aabf-138c8c8cd428",
+          "candidate": "e",
+          "roundWin": 11,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "d8c117cb-d8af-420d-a230-745925ce7f52",
+          "candidate": "w",
+          "roundWin": 4,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "8ab9e986-4cf5-43ec-a210-ab1b70663d3b",
+          "candidate": "t",
+          "roundWin": 2,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "90a2b79c-01bd-4a0b-a364-0144b2094464",
+          "candidate": "t",
+          "roundWin": 5,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "d97b1481-40ef-4752-aea6-927727c2f576",
+          "candidate": "y",
+          "roundWin": 10,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "4316d17f-3289-45be-97c4-afd580688b14",
+          "candidate": "j",
+          "roundWin": 7,
+          "roundLose": 5,
+          "champion": 1
+        },
+        {
+          "id": "ea9db2b5-f57f-449a-b9b8-96a4aaff3ea3",
+          "candidate": "v",
+          "roundWin": 4,
+          "roundLose": 6,
+          "champion": 0
+        },
+        {
+          "id": "a40a9b73-d280-497c-a43a-ddfde9ebc5f5",
+          "candidate": "f",
+          "roundWin": 4,
+          "roundLose": 6,
+          "champion": 0
+        }
+      ],
+      "id": "b8ebff95-9bb0-4529-b5c6-b9cb0fe395cf",
+      "count": 6,
+      "createdAt": 1646567190036,
+      "comments": []
+    },
+    {
+      "title": "hjk",
+      "list": [
+        {
+          "id": "d2ab8daf-b925-45ba-b924-8119f5888511",
+          "candidate": "jkh",
+          "roundWin": 4,
+          "roundLose": 0,
+          "champion": 1
+        },
+        {
+          "id": "56263fe7-7bb1-49aa-a795-83618fbedc53",
+          "candidate": "kjh",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "f24f66e5-db9c-4e55-9b5f-0f7dcbbac017",
+          "candidate": "kjh",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "8cbf3f8e-85f9-459b-ab52-9ce28f9ba61b",
+          "candidate": "jkhjhk",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "bbbf3f77-7aab-4be2-8fb0-4cb1b8794612",
+          "candidate": "jkh",
+          "roundWin": 2,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "e15dd7a3-26ba-43a2-aee5-acd44d30b6c1",
+          "candidate": "khj",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "6ae5aaca-417b-4b10-bb42-ad8972d12d44",
+          "candidate": "hkj",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "f2f11a97-9823-4a0f-b296-6132cd929533",
+          "candidate": "khj",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "c2f70c1e-5f08-4986-a1b6-6ba99d8f953d",
+          "candidate": "jhhk",
+          "roundWin": 3,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "2bb78ec9-1993-4413-a66c-8fc9bb5d7858",
+          "candidate": "jkh",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "35b7709b-0be3-4541-bcc6-a38f4ef8d6c2",
+          "candidate": "hjkk",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "766e885d-f770-4b95-a081-ce9edffd8264",
+          "candidate": "hkj",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "c41e0992-4b43-472b-ae1c-46a122343c80",
+          "candidate": "hj",
+          "roundWin": 2,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "59909aab-17c7-4e20-ab15-c846245fe5cb",
+          "candidate": "jh",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "f07fb037-df7c-4efc-8e82-5c6cbb361068",
+          "candidate": "jkh",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "83ab492f-7d7e-4e8e-8e7e-c3873f2f9e5a",
+          "candidate": "jkh",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        }
+      ],
+      "id": "ef794c43-6e75-407d-a170-156f4ffa764b",
+      "count": 1,
+      "createdAt": 1646570140072,
+      "comments": []
+    },
+    {
+      "title": "테스트",
+      "list": [
+        {
+          "id": "01e26e83-8975-4742-abeb-44a76084e0fb",
+          "candidate": "ㄹㅎ",
+          "roundWin": 4,
+          "roundLose": 0,
+          "champion": 1
+        },
+        {
+          "id": "1f00db71-4fd4-4ad7-8a60-601a0aba8d1c",
+          "candidate": "ㅂ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "48b1438d-05f4-49ca-9ea7-8447c0fac749",
+          "candidate": "ㅕ",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "c28e6980-2825-47b3-aa64-6fc85617a1f3",
+          "candidate": "ㅎㅇㅁ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "82108978-bc46-4860-b8fe-43070e02f0d9",
+          "candidate": "ㅔ",
+          "roundWin": 2,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "b52da254-4cdb-4cf7-910b-a60eadaf7774",
+          "candidate": "ㅑ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "85a7a39c-d4bd-44b5-be08-ab3efa7144a8",
+          "candidate": "ㅇ",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "d900040c-d24b-4076-b7c2-4244c987a1e0",
+          "candidate": "ㄱ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "262a9d38-7a82-4994-9516-62b64697e77a",
+          "candidate": "ㅛ",
+          "roundWin": 3,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "f94ef9ec-b301-4305-ae14-58ad2230688a",
+          "candidate": "ㅐ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "685aa4b7-6e32-4994-a607-2301865c9842",
+          "candidate": "ㅁ",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "c246f49d-50ec-4f45-a581-a3464cfbf149",
+          "candidate": "ㄷ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "ed1d951a-97e2-42a6-aa13-25773b2a38d3",
+          "candidate": "ㅅ",
+          "roundWin": 2,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "6a7d3bd3-fe61-4877-98eb-272f109b4835",
+          "candidate": "ㅈ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "73005733-c018-447e-acc5-581bd252e9af",
+          "candidate": "ㄴ",
+          "roundWin": 1,
+          "roundLose": 1,
+          "champion": 0
+        },
+        {
+          "id": "b20c8c87-2135-4eaa-a557-cbbfb4c44f4b",
+          "candidate": "ㄹ",
+          "roundWin": 0,
+          "roundLose": 1,
+          "champion": 0
+        }
+      ],
+      "id": "cfac7b8e-f225-4ecb-b5e3-c6dbcce5898e",
+      "count": 1,
+      "createdAt": 1646577247743,
       "comments": []
     }
   ]

--- a/db.json
+++ b/db.json
@@ -1,626 +1,140 @@
 {
   "world": [
     {
-      "title": "음식월드컵",
+      "title": "월",
       "list": [
         {
-          "id": "ced30966-1056-4e6f-8136-774973be232d",
-          "candidate": "콩나물국",
-          "score": 28
+          "id": "d0831be3-747d-4d03-a699-64dd0b26df7d",
+          "candidate": "1",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "af49b2e5-08cc-4b25-9a9b-93cec88033a5",
-          "candidate": "김치국",
-          "score": 17
+          "id": "70223f72-076b-49ec-a45a-59dbd815682c",
+          "candidate": "2",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "db300846-4a04-4a0c-8be0-73cc5a778349",
-          "candidate": "코다리찜",
-          "score": 18
+          "id": "37f49423-aea8-4ebe-864c-3c398491f408",
+          "candidate": "3",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "d1b3a754-4db4-4fdc-9d6d-d70e155fa57e",
-          "candidate": "양곱창",
-          "score": 26
+          "id": "454d0e91-4e59-4ca1-b7cf-feff7261a643",
+          "candidate": "4",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "7c7156bd-a75e-4a89-a0a9-8da79c4684b0",
-          "candidate": "된장찌개",
-          "score": 11
+          "id": "84e1f877-4042-446f-b55b-09532e5e852f",
+          "candidate": "5",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "d4cb8a8f-ffcf-4b7f-8acd-4505d969a4e2",
-          "candidate": "김치돼지갈비찜",
-          "score": 19
+          "id": "33a815f7-2e55-4103-97ba-3386263d1bf1",
+          "candidate": "6",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "a04f735c-f78f-44e8-89e3-9762be3f209d",
-          "candidate": "삼겹살",
-          "score": 15
+          "id": "771e2113-bd71-4cce-8d17-262a6dccf304",
+          "candidate": "7",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "8fc8f825-8b0a-45d4-b498-012fdb633e10",
-          "candidate": "소곱창",
-          "score": 21
+          "id": "4b360218-d12c-4d84-b316-119f1fa21717",
+          "candidate": "8",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "86aec635-bbac-4d0e-a21f-0fa6ce7a4156",
-          "candidate": "칼국수",
-          "score": 30
+          "id": "8de17c88-8a1b-4c50-b54d-b174ce6537ea",
+          "candidate": "9",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "19a54ba5-794a-4359-8477-51392e78af7f",
-          "candidate": "콩자반",
-          "score": 17
+          "id": "5257398b-3d0a-4402-8cda-b5e19f8e40c6",
+          "candidate": "10",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "0e7348b8-6c50-42f6-a68b-1b844eddf9ba",
-          "candidate": "두부부침",
-          "score": 15
+          "id": "c74d7d89-cc2b-4605-b790-fef0cd22929e",
+          "candidate": "11",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "6b8caa81-5fe8-4acd-9536-05cd81afcc77",
-          "candidate": "불고기",
-          "score": 52
+          "id": "1752a3ee-07b3-43e5-8c97-a0d92a6dd39b",
+          "candidate": "12",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "1f138893-15d2-40ef-bf87-4310f45d6a66",
-          "candidate": "호박찜",
-          "score": 14
+          "id": "c050fc31-fb31-475c-b2c5-48c698094b0e",
+          "candidate": "13",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "7468db7b-2dfb-4a93-98aa-3927faab175e",
-          "candidate": "비빔밥",
-          "score": 36
+          "id": "471e8f84-e258-4094-8101-10d87d5466f4",
+          "candidate": "14",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "269a85ff-e0d9-4438-a5d7-b91fb138eaba",
-          "candidate": "순댓국",
-          "score": 12
+          "id": "7e565790-2473-46ff-bc05-c5e6658bbc81",
+          "candidate": "15",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         },
         {
-          "id": "bceadd0e-1ea4-4fe6-a559-b50f9f8797d2",
-          "candidate": "돼지갈비",
-          "score": 29
+          "id": "279cdbcc-eb7b-4448-bb08-ed3c663b34ba",
+          "candidate": "16",
+          "score": 0,
+          "roundWin": 0,
+          "roundLose": 0,
+          "champion": 0
         }
       ],
-      "id": "329fbe57-a354-4d22-8614-1f205b5fb1ac",
-      "count": 10,
-      "createdAt": 1646472577229,
-      "comments": []
-    },
-    {
-      "title": "hk31232",
-      "list": [
-        {
-          "id": "68348674-41e3-4494-ac0b-04f5c56e9869",
-          "candidate": "jkh",
-          "score": 5
-        },
-        {
-          "id": "bd19a305-21da-4711-96ef-a4db2a963ad7",
-          "candidate": "khj",
-          "score": 1
-        },
-        {
-          "id": "5961776b-db8d-4952-97e1-f750dd2c1bfa",
-          "candidate": "jk321",
-          "score": 1
-        },
-        {
-          "id": "52f402de-6701-4fc3-9985-f87e55c42f40",
-          "candidate": "jhk",
-          "score": 4
-        },
-        {
-          "id": "9548b20e-6517-41c8-980d-5805e80d2e87",
-          "candidate": "hjk",
-          "score": 2
-        },
-        {
-          "id": "022a5902-aa2a-43ad-a734-254c1e4e47ba",
-          "candidate": "kjhk",
-          "score": 2
-        },
-        {
-          "id": "534b927b-4ae9-4139-8aaf-c9d03a7b35c6",
-          "candidate": "hjkhj",
-          "score": 1
-        },
-        {
-          "id": "d023dfa2-866f-4cab-91e3-dc837ba5030f",
-          "candidate": "hj132",
-          "score": 6
-        },
-        {
-          "id": "359945df-a9d8-428e-b0bb-a087235bf3b6",
-          "candidate": "j123",
-          "score": 3
-        },
-        {
-          "id": "7f3bd6af-700d-4198-a89c-4fda38576259",
-          "candidate": "hjk",
-          "score": 2
-        },
-        {
-          "id": "6e2f7ac4-095a-42f2-8211-5d5dcd8b30d9",
-          "candidate": "k123",
-          "score": 1
-        },
-        {
-          "id": "5adf6fce-1568-45aa-8c15-9362d2eaf59e",
-          "candidate": "hkj",
-          "score": 4
-        },
-        {
-          "id": "a305a07d-71a1-450c-a163-a1d0b4582b93",
-          "candidate": "hjkk",
-          "score": 2
-        },
-        {
-          "id": "3ee21e37-f293-40e4-89d6-579f635621d5",
-          "candidate": "hjkhj",
-          "score": 2
-        },
-        {
-          "id": "65dca3f0-4bea-4a77-8676-c6163445f77a",
-          "candidate": "hkj",
-          "score": 1
-        },
-        {
-          "id": "082a5e51-633e-405a-90ce-054745cfb476",
-          "candidate": "jkh",
-          "score": 8
-        }
-      ],
-      "id": "9f25ffaa-49f8-4a5f-bd7f-8f7e29fcaaa9",
+      "id": "6cdd7a33-9395-4d44-aa48-b7d082af537a",
       "count": 0,
-      "createdAt": 1646472692482,
-      "comments": []
-    },
-    {
-      "title": "asd",
-      "list": [
-        {
-          "id": "f7bfe993-230e-45bd-9500-ef95b6c6e2dd",
-          "candidate": "kjl",
-          "score": 4
-        },
-        {
-          "id": "5e4848d4-1c53-452c-90e1-bd2a7fc41dff",
-          "candidate": "jkljlk",
-          "score": 0
-        },
-        {
-          "id": "c249e4dd-054b-4707-ad11-9a809d9ece24",
-          "candidate": "jklljk",
-          "score": 1
-        },
-        {
-          "id": "42a58923-250c-4c0a-a4cb-6199b8a705af",
-          "candidate": "jklljk",
-          "score": 0
-        },
-        {
-          "id": "16dd532b-88bb-4446-b991-53489c4bcb5c",
-          "candidate": "jlk",
-          "score": 2
-        },
-        {
-          "id": "8b2a8495-9bbc-4993-8576-2d12d69ad826",
-          "candidate": "jks",
-          "score": 0
-        },
-        {
-          "id": "008f4584-b919-493f-ac20-1a946b0c06a4",
-          "candidate": "ljk",
-          "score": 1
-        },
-        {
-          "id": "24910aaf-85b2-48c8-a583-0ff208c3d0ae",
-          "candidate": "ljk",
-          "score": 0
-        },
-        {
-          "id": "eeac21c1-6328-44a1-831f-f8ec26cd7cc9",
-          "candidate": "jlk",
-          "score": 3
-        },
-        {
-          "id": "7a121ca2-5347-41aa-b3e2-86b264da375a",
-          "candidate": "lkj",
-          "score": 0
-        },
-        {
-          "id": "507c4da3-2d87-4590-81a2-8f464949720e",
-          "candidate": "jkll",
-          "score": 1
-        },
-        {
-          "id": "dd726608-71c8-4bd2-aa09-74cb5c61669c",
-          "candidate": "jkj",
-          "score": 0
-        },
-        {
-          "id": "6e0ea4e4-14ca-4c80-8579-c31ba57ccfd4",
-          "candidate": "klkj",
-          "score": 2
-        },
-        {
-          "id": "c392c060-2e15-4c4f-8ba3-11e724b39ad5",
-          "candidate": "jkl",
-          "score": 0
-        },
-        {
-          "id": "361b3a20-5c2d-49be-bc85-101af38360a5",
-          "candidate": "jlk",
-          "score": 1
-        },
-        {
-          "id": "04cf9eec-9096-4e34-abef-758d6a96cfa1",
-          "candidate": "jlk",
-          "score": 0
-        }
-      ],
-      "id": "78d36270-a029-457a-9a39-f6c547c80ae2",
-      "count": 0,
-      "createdAt": 1646473055851,
-      "comments": []
-    },
-    {
-      "title": "로아 개사기 직업 월드컵",
-      "list": [
-        {
-          "id": "dec0e00c-d337-46a1-ac5d-e6f50fd09e9d",
-          "candidate": "창술사",
-          "score": 5
-        },
-        {
-          "id": "079d8c7e-250b-41f8-b374-a83cfb820abe",
-          "candidate": "바드 . ",
-          "score": 0
-        },
-        {
-          "id": "c7060375-16c9-49b2-a519-c34eb1780482",
-          "candidate": "인파이터 ",
-          "score": 2
-        },
-        {
-          "id": "8c80ebe4-90c4-487e-b0b9-5f2449c6dc2f",
-          "candidate": "기공사",
-          "score": 1
-        },
-        {
-          "id": "9f6a9666-afc5-4fab-85d7-26a3517a0404",
-          "candidate": "배틀마스터",
-          "score": 1
-        },
-        {
-          "id": "f34b45ad-eac7-474e-80cf-e195f8e2bd0b",
-          "candidate": "워로드",
-          "score": 1
-        },
-        {
-          "id": "ca3c31e3-b666-40f9-bcfe-7e45aa25d232",
-          "candidate": "버서커",
-          "score": 5
-        },
-        {
-          "id": "88754f6b-d8f9-4263-8ab1-482228ee35a7",
-          "candidate": "디스트로이어",
-          "score": 0
-        },
-        {
-          "id": "e8fde393-1cd7-4295-9fb4-3e9ed2a559b7",
-          "candidate": "호크아이",
-          "score": 1
-        },
-        {
-          "id": "47af7607-bcea-47a4-8415-a86b12bbe0e4",
-          "candidate": "스카우터",
-          "score": 2
-        },
-        {
-          "id": "66512ed3-cf7e-4ea9-aef8-381c40b62d9c",
-          "candidate": "데빌헌터",
-          "score": 1
-        },
-        {
-          "id": "02db8d24-7aff-4cce-86f6-67218ca878a1",
-          "candidate": "블래스터",
-          "score": 3
-        },
-        {
-          "id": "c12bbc8d-4ea3-48bd-a7cc-ffa2a1185c5b",
-          "candidate": "블레이드",
-          "score": 4
-        },
-        {
-          "id": "700f4c2e-5c63-4fe8-bc26-a38f61135531",
-          "candidate": "리퍼.",
-          "score": 2
-        },
-        {
-          "id": "bd4fa81c-a866-436a-a8ee-d5d932b08286",
-          "candidate": "데모닉",
-          "score": 1
-        },
-        {
-          "id": "39277194-027f-4131-830d-52e79f377595",
-          "candidate": "건슬링어",
-          "score": 1
-        }
-      ],
-      "id": "31c0e56f-c18c-49e8-b326-542b97eb2901",
-      "count": 1,
-      "createdAt": 1646501869114,
-      "comments": []
-    },
-    {
-      "title": "테스트 월드컵",
-      "list": [
-        {
-          "id": "dad277f4-0ed4-4f51-965f-86ee2efcc618",
-          "candidate": "ㄲㄲㄱ",
-          "score": 1
-        },
-        {
-          "id": "193c6e6f-4269-4bb1-ae45-79263e882214",
-          "candidate": "ㅎㅎㅎㅎㅎㅎ",
-          "score": 2
-        },
-        {
-          "id": "3bc490df-2a42-4f69-94d5-a77a8a19b06b",
-          "candidate": "ㅌㅌㅌㅌㅌㅌ",
-          "score": 1
-        },
-        {
-          "id": "379e55be-e3e2-41c2-8ade-7d210edf7e8c",
-          "candidate": "ㄸㄸㄸ",
-          "score": 0
-        },
-        {
-          "id": "692134b1-b565-4ba0-9ef3-e0bd079329d9",
-          "candidate": "ㅊㅊㅊㅊㅊㅊ",
-          "score": 2
-        },
-        {
-          "id": "ff80ebf1-06e5-49e6-a204-749605937fb0",
-          "candidate": "ㅁㅁㅁㅁㅁㅁ",
-          "score": 5
-        },
-        {
-          "id": "240f8226-edd4-49d0-a119-4394bdf3eed2",
-          "candidate": "ㅆㅆㅆ",
-          "score": 6
-        },
-        {
-          "id": "1f8506b3-bd52-468e-91e2-5958b81bdf55",
-          "candidate": "ㅋㅋㅋㅋㅋㅋ",
-          "score": 9
-        },
-        {
-          "id": "d6d87172-f1f9-418b-87f8-05ed20f54fb1",
-          "candidate": "ㄹㄹㄹㄹㄹ",
-          "score": 3
-        },
-        {
-          "id": "eb73f87c-8d26-4e05-8f15-d5e4de0a8880",
-          "candidate": "ㅉㅉㅉ",
-          "score": 3
-        },
-        {
-          "id": "0832afd0-8945-45cd-a1df-160f8017226e",
-          "candidate": "ㅃㅃㅃㅂ",
-          "score": 1
-        },
-        {
-          "id": "4baed498-a3b6-43ca-a4db-6b339520b843",
-          "candidate": "ㅇㅇㅇㅇㅇ",
-          "score": 0
-        },
-        {
-          "id": "b21b88df-e14a-4812-b05c-cb89288a6bc6",
-          "candidate": "ㅍㅍㅍㅍㅍㅎㅎ",
-          "score": 2
-        },
-        {
-          "id": "e91133b6-dea4-481e-a20c-049deb5e06e2",
-          "candidate": "ㅏㅏㅏㅏ",
-          "score": 6
-        },
-        {
-          "id": "6eca391a-7d98-4e4d-934a-778291236616",
-          "candidate": "ㄴㄴㄴㄴ",
-          "score": 2
-        },
-        {
-          "id": "4b79909e-b409-4c2b-ab3d-7d8de2ed79df",
-          "candidate": "ㅔㅔㅔㅔㅔㅔㅔ",
-          "score": 2
-        }
-      ],
-      "id": "945fed7a-f815-4f8f-b15b-c7a7b3972bdd",
-      "count": 5,
-      "createdAt": 1646511015415,
-      "comments": []
-    },
-    {
-      "title": "테스트 월드컵",
-      "list": [
-        {
-          "id": "069c4381-6f8e-41ce-9737-3cdd6c51ef72",
-          "candidate": "eee",
-          "score": 7
-        },
-        {
-          "id": "1cc8ac44-b09e-48b0-80f3-2b423c9a8725",
-          "candidate": "4444",
-          "score": 1
-        },
-        {
-          "id": "608d57d8-e053-4eba-8ff9-efa4d6e3c9b4",
-          "candidate": "ddd",
-          "score": 5
-        },
-        {
-          "id": "8750b285-54d9-41a7-b10b-c226b4bcf81b",
-          "candidate": "888",
-          "score": 4
-        },
-        {
-          "id": "add40c91-4e78-4ab8-b505-657acfa76cd3",
-          "candidate": "777",
-          "score": 4
-        },
-        {
-          "id": "3f8f56e5-6139-45a4-8e85-fb1b36d6acce",
-          "candidate": "333",
-          "score": 1
-        },
-        {
-          "id": "714bb5dd-936c-416c-80f5-c94f68e530db",
-          "candidate": "222",
-          "score": 5
-        },
-        {
-          "id": "aacd1cd1-32ed-4d94-b855-a36dcec9b60f",
-          "candidate": "555",
-          "score": 0
-        },
-        {
-          "id": "5d1cf07a-d409-4ee9-b5b9-330b9ef8b613",
-          "candidate": "ggg",
-          "score": 4
-        },
-        {
-          "id": "ebaab1f0-a7c0-48b1-9146-d4ddf06e783e",
-          "candidate": "fff",
-          "score": 1
-        },
-        {
-          "id": "aaa8f522-b512-43e4-8675-a11a83288774",
-          "candidate": "aaaa",
-          "score": 5
-        },
-        {
-          "id": "8e9c4882-1188-4fc6-8944-9d01242c2c04",
-          "candidate": "ccc",
-          "score": 2
-        },
-        {
-          "id": "86911f9f-73f1-4482-bbbf-456d15148400",
-          "candidate": "999",
-          "score": 3
-        },
-        {
-          "id": "d67631fe-1a7f-48b0-9e22-d9f605984a72",
-          "candidate": "111",
-          "score": 5
-        },
-        {
-          "id": "d973c38f-0ddf-4122-bcf1-f6d0424873d0",
-          "candidate": "666",
-          "score": 3
-        },
-        {
-          "id": "0c302c98-50c7-4dd3-973e-e76e302f6449",
-          "candidate": "bbb",
-          "score": 5
-        }
-      ],
-      "id": "5e4ddb2d-a626-4cac-8c0f-dc08ff72a085",
-      "count": 4,
-      "createdAt": 1646556028726,
-      "comments": []
-    },
-    {
-      "title": "테스트월드컵33",
-      "list": [
-        {
-          "id": "33ed7396-fcff-4fbb-a9c4-ba33ad30f48c",
-          "candidate": "카카카",
-          "score": 4
-        },
-        {
-          "id": "31a547c9-5319-4aa9-9d3f-d9c05128c6da",
-          "candidate": "222",
-          "score": 0
-        },
-        {
-          "id": "ed90df7b-4984-4f6d-8e9c-e46ac232614a",
-          "candidate": "아아아",
-          "score": 1
-        },
-        {
-          "id": "4e66217a-e823-4094-b8ef-603f1517dc40",
-          "candidate": "다다다",
-          "score": 0
-        },
-        {
-          "id": "3f927d5f-2b01-468f-99c0-21d06422f9ce",
-          "candidate": "111",
-          "score": 2
-        },
-        {
-          "id": "293db475-b7cf-493b-8158-5277d6b46d82",
-          "candidate": "바바바",
-          "score": 0
-        },
-        {
-          "id": "e95a0bd3-4ee2-4232-b59c-c7643a59548a",
-          "candidate": "라라라",
-          "score": 1
-        },
-        {
-          "id": "2db8017d-a0e9-4ccf-a207-5121e82b3846",
-          "candidate": "가가가",
-          "score": 0
-        },
-        {
-          "id": "92b057f6-09e0-452f-b0df-7a02794ed652",
-          "candidate": "자자자",
-          "score": 3
-        },
-        {
-          "id": "c47a0518-2667-49b3-b448-fcf619882b41",
-          "candidate": "나나나",
-          "score": 0
-        },
-        {
-          "id": "cbf1a1dc-471b-4362-9876-b20caa7f94af",
-          "candidate": "마마마",
-          "score": 1
-        },
-        {
-          "id": "f4f27b55-3879-44f6-ab80-310ddb16c103",
-          "candidate": "파파파",
-          "score": 0
-        },
-        {
-          "id": "bd6b1391-3bb1-4f43-a635-aafc370cd5c2",
-          "candidate": "타타타",
-          "score": 2
-        },
-        {
-          "id": "db3c114c-d9bb-45ea-97ae-095d5a61eaf4",
-          "candidate": "차차차",
-          "score": 0
-        },
-        {
-          "id": "e45dcb46-74a6-41fc-82fc-f8ff6864c8b1",
-          "candidate": "하하하",
-          "score": 1
-        },
-        {
-          "id": "8c968a26-1b83-4689-aed0-1a1c5b9aacd3",
-          "candidate": "사사사",
-          "score": 0
-        }
-      ],
-      "id": "365ee042-60ae-4f9e-b3be-de9267bcbe3e",
-      "count": 1,
-      "createdAt": 1646556453356,
+      "createdAt": 1646559455739,
       "comments": []
     }
   ]

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -35,12 +35,10 @@ export default function Home() {
   const [listArr, setListArr] = useState<any>([{}]);
   useEffect(() => {
     axios.get('http://localhost:4000/world').then((res) => {
-      console.log(res);
       setListArr(res.data);
     });
   }, []);
 
-  console.log(listArr);
   const goToWorldCup = (item: any) => {
     navigate(`/world/${item.id}`);
   };

--- a/src/pages/makeWorldCup/MakeWorldCup.tsx
+++ b/src/pages/makeWorldCup/MakeWorldCup.tsx
@@ -61,7 +61,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem1,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -69,7 +68,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem2,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -77,7 +75,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem3,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -85,7 +82,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem4,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -93,7 +89,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem5,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -101,7 +96,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem6,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -109,7 +103,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem7,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -117,7 +110,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem8,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -125,7 +117,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem9,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -133,7 +124,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem10,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -141,7 +131,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem11,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -149,7 +138,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem12,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -157,7 +145,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem13,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -165,7 +152,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem14,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -173,7 +159,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem15,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,
@@ -181,7 +166,6 @@ export default function MakeWorldCup() {
       {
         id: uuidv4(),
         candidate: data.worldCupItem16,
-        score: 0,
         roundWin: 0,
         roundLose: 0,
         champion: 0,

--- a/src/pages/makeWorldCup/MakeWorldCup.tsx
+++ b/src/pages/makeWorldCup/MakeWorldCup.tsx
@@ -58,22 +58,134 @@ export default function MakeWorldCup() {
   const onSubmit = async (data: any) => {
     console.log(data);
     let listArr = [
-      { id: uuidv4(), candidate: data.worldCupItem1, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem2, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem3, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem4, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem5, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem6, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem7, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem8, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem9, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem10, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem11, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem12, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem13, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem14, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem15, score: 0 },
-      { id: uuidv4(), candidate: data.worldCupItem16, score: 0 },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem1,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem2,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem3,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem4,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem5,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem6,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem7,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem8,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem9,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem10,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem11,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem12,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem13,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem14,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem15,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
+      {
+        id: uuidv4(),
+        candidate: data.worldCupItem16,
+        score: 0,
+        roundWin: 0,
+        roundLose: 0,
+        champion: 0,
+      },
     ];
     axios
       .post('http://localhost:4000/world', {
@@ -96,7 +208,7 @@ export default function MakeWorldCup() {
         <Title
           {...register('title', {
             required: ERROR_REQUIRED,
-            minLength: { value: 3, message: ERROR_MIN },
+            minLength: { value: 1, message: ERROR_MIN },
           })}
         />
         {errors.title && <p>{errors.title?.message}</p>}
@@ -107,7 +219,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}1`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -123,7 +235,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}2`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -139,7 +251,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}3`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -155,7 +267,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}4`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -173,7 +285,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}5`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -189,7 +301,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}6`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -205,7 +317,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}7`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -221,7 +333,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}8`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -239,7 +351,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}9`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -255,7 +367,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}10`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -271,7 +383,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}11`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -287,7 +399,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}12`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -305,7 +417,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}13`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -321,7 +433,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}14`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -337,7 +449,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}15`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {
@@ -353,7 +465,7 @@ export default function MakeWorldCup() {
                 {...register(`${WORLD_CUP_ITEM}16`, {
                   required: ERROR_REQUIRED,
                   minLength: {
-                    value: 3,
+                    value: 1,
                     message: ERROR_MIN,
                   },
                   maxLength: {

--- a/src/pages/ranking/Ranking.tsx
+++ b/src/pages/ranking/Ranking.tsx
@@ -2,6 +2,7 @@ import axios from 'axios';
 import React, { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
+import { setEnvironmentData } from 'worker_threads';
 
 const Container = styled.div`
   width: 100%;
@@ -9,7 +10,7 @@ const Container = styled.div`
 `;
 
 const TitleText: any = styled.p`
-  font-size: 23px;
+  font-size: 17px;
   font-weight: 700;
 `;
 
@@ -23,32 +24,48 @@ const TitleWrapper = styled.div`
 
 const RankingTitle = styled.div`
   background-color: beige;
-  width: 15%;
+  width: 5%;
   height: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
+
+  padding: 15px;
+  border: 2px solid white;
 `;
 
 const NameTitle = styled.div`
   background-color: aqua;
-  width: 30%;
+  width: 15%;
   height: 100%;
   display: flex;
   justify-content: center;
-  align-items: center;
+
+  padding: 15px;
+  border: 2px solid white;
 `;
 
 const PercentTitle = styled.div`
   background-color: orange;
-  width: 55%;
+  width: 20%;
   height: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  padding: 15px;
+  border: 2px solid white;
+
+  /* justify-content: center;
+  align-items: center; */
 `;
-// const Container = styled.div``;
-// const Container = styled.div``;
+const ChartWrapper = styled.div`
+  width: 100%;
+  height: 15px;
+  padding: 3px;
+  background-color: white;
+  border-radius: 5px;
+`;
+const Chart = styled.div`
+  height: 100%;
+  background-color: pink;
+  border-radius: 2px;
+`;
 // const Container = styled.div``;
 // const Container = styled.div``;
 // const Container = styled.div``;
@@ -64,25 +81,30 @@ export default function Ranking() {
 
   const location = useLocation();
   const keyword = location.pathname.slice(9);
-
   useEffect(() => {
     axios.get(`http://localhost:4000/world?id=${keyword}`).then((res) => {
-      setData(res.data[0].list.sort((a: any, b: any) => b.score - a.score));
+      const sortRoundWin: any = res.data[0].list.sort(
+        (a: any, b: any) =>
+          b.roundWin / (b.roundWin + b.roundLose) -
+          a.roundWin / (a.roundWin + a.roundLose)
+      );
+      setData(sortRoundWin.sort((a: any, b: any) => b.champion - a.champion));
+      setData(sortRoundWin);
       setCount(res.data[0].count);
     });
   }, []);
 
-  const winnerPercent = (num: any) => {
-    let sumScore: number = 0;
-    for (let i = 0; i < data.length; i++) {
-      sumScore += data[i].score;
-    }
-    const percent: number = (num / sumScore) * 100;
+  const roundWinPercent = (roundWin: number, roundLose: number) => {
+    const percent: number = (roundWin / (roundWin + roundLose)) * 100;
     return percent.toFixed(1);
   };
 
-  console.log(count);
-  console.log(data && data);
+  const championPercent = (num: any) => {
+    const percent: number = (num / count) * 100;
+    return percent.toFixed(1);
+  };
+
+  console.log(data);
 
   return (
     <Container>
@@ -93,12 +115,18 @@ export default function Ranking() {
         <NameTitle>
           <TitleText>이름</TitleText>
         </NameTitle>
-
         <PercentTitle>
           <TitleText>
             우승비율
             <br />
             (최종 우승 횟수 / 전체 게임수)
+          </TitleText>
+        </PercentTitle>
+        <PercentTitle>
+          <TitleText>
+            라운드 승률
+            <br />
+            (라운드 이긴 횟수 / 라운드 진행 수)
           </TitleText>
         </PercentTitle>
       </TitleWrapper>
@@ -112,7 +140,22 @@ export default function Ranking() {
               <TitleText>{ele.candidate}</TitleText>
             </NameTitle>
             <PercentTitle>
-              <TitleText>{winnerPercent(ele.score)}%</TitleText>
+              <TitleText>{championPercent(ele.champion)}%</TitleText>
+              <ChartWrapper>
+                <Chart style={{ width: `${championPercent(ele.champion)}%` }} />
+              </ChartWrapper>
+            </PercentTitle>
+            <PercentTitle>
+              <TitleText>
+                {roundWinPercent(ele.roundWin, ele.roundLose)}%
+              </TitleText>
+              <ChartWrapper>
+                <Chart
+                  style={{
+                    width: `${roundWinPercent(ele.roundWin, ele.roundLose)}%`,
+                  }}
+                />
+              </ChartWrapper>
             </PercentTitle>
           </TitleWrapper>
         ))}

--- a/src/pages/ranking/Ranking.tsx
+++ b/src/pages/ranking/Ranking.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
   height: 100%;
 `;
 
-const TitleText = styled.p`
+const TitleText: any = styled.p`
   font-size: 23px;
   font-weight: 700;
 `;
@@ -40,7 +40,7 @@ const NameTitle = styled.div`
 `;
 
 const PercentTitle = styled.div`
-  background-color: green;
+  background-color: orange;
   width: 55%;
   height: 100%;
   display: flex;
@@ -60,19 +60,30 @@ const PercentTitle = styled.div`
 
 export default function Ranking() {
   const [data, setData] = useState<any>();
+  const [count, setCount] = useState<number>(0);
 
   const location = useLocation();
   const keyword = location.pathname.slice(9);
 
   useEffect(() => {
-    axios
-      .get(`http://localhost:4000/world?id=${keyword}`)
-      .then((res) => setData(res.data[0]));
+    axios.get(`http://localhost:4000/world?id=${keyword}`).then((res) => {
+      setData(res.data[0].list.sort((a: any, b: any) => b.score - a.score));
+      setCount(res.data[0].count);
+    });
   }, []);
 
-  console.log(data && data.list);
+  const winnerPercent = (num: any) => {
+    let sumScore: number = 0;
+    for (let i = 0; i < data.length; i++) {
+      sumScore += data[i].score;
+    }
+    const percent: number = (num / sumScore) * 100;
+    return percent.toFixed(1);
+  };
 
-  if (!data) return null;
+  console.log(count);
+  console.log(data && data);
+
   return (
     <Container>
       <TitleWrapper>
@@ -91,19 +102,20 @@ export default function Ranking() {
           </TitleText>
         </PercentTitle>
       </TitleWrapper>
-      {data.list.map((ele: any, idx: number) => (
-        <TitleWrapper key={idx}>
-          <RankingTitle>
-            <TitleText>{idx + 1}위</TitleText>
-          </RankingTitle>
-          <NameTitle>
-            <TitleText>{ele.candidate}</TitleText>
-          </NameTitle>
-          <PercentTitle>
-            <TitleText>{ele.score}</TitleText>
-          </PercentTitle>
-        </TitleWrapper>
-      ))}
+      {data &&
+        data.map((ele: any, idx: number) => (
+          <TitleWrapper key={idx}>
+            <RankingTitle>
+              <TitleText>{idx + 1}위</TitleText>
+            </RankingTitle>
+            <NameTitle>
+              <TitleText>{ele.candidate}</TitleText>
+            </NameTitle>
+            <PercentTitle>
+              <TitleText>{winnerPercent(ele.score)}%</TitleText>
+            </PercentTitle>
+          </TitleWrapper>
+        ))}
     </Container>
   );
 }

--- a/src/pages/worldCup/WorldCup.tsx
+++ b/src/pages/worldCup/WorldCup.tsx
@@ -66,14 +66,6 @@ function WorldCup() {
   const location = useLocation();
   const keyword = location.pathname.slice(7);
 
-  useEffect(() => {
-    if (modal) {
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = 'auto';
-    }
-  }, [modal]);
-
   const toggleModal = () => {
     setModal(!modal);
   };
@@ -130,12 +122,30 @@ function WorldCup() {
         .then((res) => console.log('성공'));
     }
   }, [winner]);
+
+  console.log(data);
+
   const setDraw = (addNum: number, setListFunction: any, setList: any) => {
     setListFunction((prev: any) => {
       const winnerList = setList[index + addNum];
       return [...prev, winnerList];
     });
-    setList[index + addNum].score += 1;
+    if (addNum === 0) {
+      setList[index].roundWin += 1;
+      setList[index + 1].roundLose += 1;
+    }
+    if (addNum === 1) {
+      setList[index + 1].roundWin += 1;
+      setList[index].roundLose += 1;
+    }
+    if (setListFunction === setWinner) {
+      if (addNum === 0) {
+        setList[index].champion += 1;
+      }
+      if (addNum === 1) {
+        setList[index + 1].champion += 1;
+      }
+    }
   };
 
   const selectCondidate = (addNum: number) => {

--- a/src/pages/worldCup/WorldCup.tsx
+++ b/src/pages/worldCup/WorldCup.tsx
@@ -63,7 +63,6 @@ function WorldCup() {
   const [winner, setWinner] = useState<any>([]);
   const [roundInfo, setRoundInfo] = useState<string>('🏆 16강전');
   const [modal, setModal] = useState(false);
-
   const location = useLocation();
   const keyword = location.pathname.slice(7);
 
@@ -79,10 +78,20 @@ function WorldCup() {
     setModal(!modal);
   };
 
+  const shuffleArray = (array: any) => {
+    for (let i = 0; i < array.length; i++) {
+      let j = Math.floor(Math.random() * (i + 1));
+      [array[i], array[j]] = [array[j], array[i]];
+    }
+    return array;
+  };
+
   useEffect(() => {
     axios
       .get(`http://localhost:4000/world?id=${keyword}`)
-      .then((res) => (setData(res.data[0]), setList(res.data[0].list)));
+      .then(
+        (res) => (setData(res.data[0]), setList(shuffleArray(res.data[0].list)))
+      );
   }, []);
 
   useEffect(() => {
@@ -116,15 +125,11 @@ function WorldCup() {
         .put(`http://localhost:4000/world/${keyword}`, {
           ...data,
           list: data.list,
+          count: (data.count += 1),
         })
         .then((res) => console.log('성공'));
-      // .catch((error) => console.log(error));
     }
   }, [winner]);
-  console.log(data.list);
-
-  // console.log(data);
-
   const setDraw = (addNum: number, setListFunction: any, setList: any) => {
     setListFunction((prev: any) => {
       const winnerList = setList[index + addNum];
@@ -168,7 +173,6 @@ function WorldCup() {
     const addNum = 1;
     selectCondidate(addNum);
   };
-  // if (!list) return null;
 
   return (
     <>


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)

- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치

feat/sungho -> dev

### 변경 사항

- 월드컵 페이지에서 처음에 리스트 배열 섞어지는 로직 추가.
- Modified : 월드컵 생성기에서 3글자 이상 입력해야 하는거 1글자로 바꿈 
- Add : roundWin , roundLose , champion API데이터 추가 및 정렬 해주는 로직 추가